### PR TITLE
Ignore cancelled damage event.

### DIFF
--- a/src/main/java/com/orcaseason/fblauncher/listener/FireballListener.java
+++ b/src/main/java/com/orcaseason/fblauncher/listener/FireballListener.java
@@ -94,7 +94,7 @@ public class FireballListener implements Listener {
         fireballCooldowns.remove(playerId);
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
         if (!(event.getEntity() instanceof Player) || !(event.getDamager() instanceof Fireball)) {
             return;


### PR DESCRIPTION
I am not really sure about open maps, but because i have WorldGuard and players will able to push each other in the spawn, i add the `ignoreCancelled` option that means if event was cancelled before, fireball logic will not apply. 